### PR TITLE
fix bernoulli to model.bounulli

### DIFF
--- a/circulant/circulant_rand.m
+++ b/circulant/circulant_rand.m
@@ -8,5 +8,5 @@ function model = circulant_rand(d)
     rr = randn(1,d);
     rr(rr > 0) = 1;
     rr(rr <= 0 ) = -1;
-    model.bernoulli = rr;
+    model.bounulli = rr;
 end


### PR DESCRIPTION
hi, felixyu

There is a bug in `circulant_rand.m`. The `model.bernoulli` should be `model.bounulli`, and I have fixed it.
